### PR TITLE
Add scraper tests and fixtures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.pytest_cache/

--- a/scraper.py
+++ b/scraper.py
@@ -1,0 +1,33 @@
+from html.parser import HTMLParser
+
+class ListItemParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.items = []
+        self._capture = False
+
+    def handle_starttag(self, tag, attrs):
+        if tag == "li":
+            self._capture = True
+
+    def handle_endtag(self, tag):
+        if tag == "li":
+            self._capture = False
+
+    def handle_data(self, data):
+        if self._capture:
+            text = data.strip()
+            if text:
+                self.items.append(text)
+
+
+def extract_data_from_soup(html: str):
+    """Extract list item text from HTML string."""
+    parser = ListItemParser()
+    parser.feed(html)
+    return parser.items
+
+
+def scrape_data_directly(html: str):
+    """Parse HTML and return list item text."""
+    return extract_data_from_soup(html)

--- a/tests/fixtures/sample.html
+++ b/tests/fixtures/sample.html
@@ -1,0 +1,5 @@
+<ul>
+<li>Item 1</li>
+<li>Item 2</li>
+<li>Item 3</li>
+</ul>

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -1,0 +1,25 @@
+import pathlib
+import sys
+
+ROOT_DIR = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT_DIR))
+
+from scraper import scrape_data_directly, extract_data_from_soup
+
+FIXTURE_DIR = pathlib.Path(__file__).parent / "fixtures"
+
+
+def load_sample_html():
+    return (FIXTURE_DIR / "sample.html").read_text()
+
+
+def test_scrape_data_directly_non_empty():
+    html = load_sample_html()
+    data = scrape_data_directly(html)
+    assert data, "scrape_data_directly should return non-empty result"
+
+
+def test_extract_data_from_soup_non_empty():
+    html = load_sample_html()
+    data = extract_data_from_soup(html)
+    assert data, "extract_data_from_soup should return non-empty result"


### PR DESCRIPTION
## Summary
- implement `scraper.py` with simple HTML parsing
- add pytest suite that validates both scraping functions
- include sample HTML fixture for tests
- ignore Python caches

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68486239c840832788ff2db108e202f5